### PR TITLE
refactor: centralize cached_property alias

### DIFF
--- a/docs/contributing/code-contribution.md
+++ b/docs/contributing/code-contribution.md
@@ -32,6 +32,18 @@ While we're working on comprehensive documentation, the codebase is designed to
 be self-explanatory. As a developer, you can understand our patterns and expectations
 by taking a look at existing scrapers in the `recipe_scrapers/` directory.
 
+For shared utilities, prefer importing from existing helpers rather than the
+standard library directly. For example, to use `cached_property`, import the
+alias from `_utils`:
+
+```py
+from recipe_scrapers._utils import cached_property
+
+@cached_property
+def example(self):
+    ...
+```
+
 
 ## Hints
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -2,6 +2,7 @@ import html
 import inspect
 import math
 import re
+from functools import cached_property
 
 import isodate
 

--- a/recipe_scrapers/americastestkitchen.py
+++ b/recipe_scrapers/americastestkitchen.py
@@ -1,10 +1,9 @@
-import functools
 import json
 
 from recipe_scrapers._grouping_utils import IngredientGroup
 
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import cached_property, get_minutes, normalize_string
 
 
 class AmericasTestKitchen(AbstractScraper):
@@ -75,7 +74,7 @@ class AmericasTestKitchen(AbstractScraper):
             .replace(" ,", ",")
         )
 
-    @functools.cached_property
+    @cached_property
     def _get_additional_details(self):
         j = json.loads(self.soup.find(type="application/json").string)
         # Handling for new page format

--- a/recipe_scrapers/bofrost.py
+++ b/recipe_scrapers/bofrost.py
@@ -1,7 +1,5 @@
-import functools
-
 from ._abstract import AbstractScraper
-from ._utils import normalize_string
+from ._utils import cached_property, normalize_string
 
 
 class Bofrost(AbstractScraper):
@@ -9,7 +7,7 @@ class Bofrost(AbstractScraper):
     def host(cls):
         return "bofrost.de"
 
-    @functools.cached_property
+    @cached_property
     def _nutrients(self):
         return self.soup.select_one(".recipe-nutrations")
 

--- a/recipe_scrapers/farmhousedelivery.py
+++ b/recipe_scrapers/farmhousedelivery.py
@@ -1,11 +1,10 @@
 import re
 
-import functools
 from bs4 import Tag
 
 from ._abstract import AbstractScraper
 from ._exceptions import FieldNotProvidedByWebsiteException
-from ._utils import normalize_string
+from ._utils import cached_property, normalize_string
 
 """
     NOTE: This website has at least 2 prominent layouts styles, so there are two logic blocks and 2 test cases to
@@ -60,7 +59,7 @@ class FarmhouseDelivery(AbstractScraper):
 
         return None
 
-    @functools.cached_property
+    @cached_property
     def _instructions_list(self):
         # Style 1
         instructions_marker = self.soup.find("p", string=re.compile(r"Instructions:"))

--- a/recipe_scrapers/felixkitchen.py
+++ b/recipe_scrapers/felixkitchen.py
@@ -1,7 +1,6 @@
-import functools
 from ._abstract import AbstractScraper
 from ._exceptions import FieldNotProvidedByWebsiteException
-from ._utils import normalize_string
+from ._utils import cached_property, normalize_string
 
 MARK_SEPARATOR = " "
 INGREDIENT_SEPARATOR = "• "
@@ -77,6 +76,6 @@ class FelixKitchen(AbstractScraper):
             lines.append(child.text)
         return "\n".join(lines)
 
-    @functools.cached_property
+    @cached_property
     def _get_step_divs(self):
         return self.soup.select('div[class*="wp-block-columns is-layout-flex"]')

--- a/recipe_scrapers/goodhousekeeping.py
+++ b/recipe_scrapers/goodhousekeeping.py
@@ -1,9 +1,8 @@
 import re
-import functools
 
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
-from ._utils import normalize_string
+from ._utils import cached_property, normalize_string
 
 
 class GoodHousekeeping(AbstractScraper):
@@ -47,7 +46,7 @@ class GoodHousekeeping(AbstractScraper):
     def cuisine(self):
         return self.schema.cuisine() or None
 
-    @functools.cached_property
+    @cached_property
     def _nutrient_soup(self):
         return self.soup.find(class_="recipe-body-content")
 

--- a/recipe_scrapers/heb.py
+++ b/recipe_scrapers/heb.py
@@ -1,6 +1,5 @@
-import functools
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, get_yields, normalize_string
+from ._utils import cached_property, get_minutes, get_yields, normalize_string
 
 
 class HEB(AbstractScraper):
@@ -28,7 +27,7 @@ class HEB(AbstractScraper):
 
         return [normalize_string(ingredient.get_text()) for ingredient in ingredients]
 
-    @functools.cached_property
+    @cached_property
     def _instructions_list(self):
         instructions_container = self.soup.find(
             "div", {"data-qe-id": "recipeInstructionsContainer"}

--- a/recipe_scrapers/kitchenaidaustralia.py
+++ b/recipe_scrapers/kitchenaidaustralia.py
@@ -1,9 +1,8 @@
-import functools
 import re
 
 from ._abstract import AbstractScraper
 from ._grouping_utils import IngredientGroup
-from ._utils import get_minutes
+from ._utils import cached_property, get_minutes
 
 
 class KitchenAidAustralia(AbstractScraper):
@@ -60,14 +59,14 @@ class KitchenAidAustralia(AbstractScraper):
 
         return self._parse_list(method)
 
-    @functools.cached_property
+    @cached_property
     def _get_recipe(self):
         """
         Get the recipe container element.
         """
         return self.soup.find("article")
 
-    @functools.cached_property
+    @cached_property
     def _get_summary(self):
         """
         Get the summary container element.

--- a/recipe_scrapers/nhshealthierfamilies.py
+++ b/recipe_scrapers/nhshealthierfamilies.py
@@ -1,9 +1,8 @@
 import re
-import functools
 
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
-from ._utils import get_minutes, get_yields, normalize_string
+from ._utils import cached_property, get_minutes, get_yields, normalize_string
 
 
 class NHSHealthierFamilies(AbstractScraper):
@@ -20,7 +19,7 @@ class NHSHealthierFamilies(AbstractScraper):
             title = title[:-7]
         return title
 
-    @functools.cached_property
+    @cached_property
     def _get_recipe_content(self):
         container = self.soup.find("div", {"class": "bh-recipe__description"})
         descriptions = container.findAll("p")

--- a/recipe_scrapers/popsugar.py
+++ b/recipe_scrapers/popsugar.py
@@ -1,6 +1,5 @@
-import functools
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, get_yields, normalize_string
+from ._utils import cached_property, get_minutes, get_yields, normalize_string
 
 
 class PopSugar(AbstractScraper):
@@ -54,6 +53,6 @@ class PopSugar(AbstractScraper):
         container = self._context.find("h3", string="Directions").parent
         return "\n".join([entry.get_text() for entry in container.findAll("li")])
 
-    @functools.cached_property
+    @cached_property
     def _context(self):
         return self.soup.find("div", {"class": "recipe-card"})

--- a/recipe_scrapers/quitoque.py
+++ b/recipe_scrapers/quitoque.py
@@ -1,6 +1,11 @@
-import functools
 from ._abstract import AbstractScraper
-from ._utils import csv_to_tags, get_minutes, get_yields, normalize_string
+from ._utils import (
+    cached_property,
+    csv_to_tags,
+    get_minutes,
+    get_yields,
+    normalize_string,
+)
 
 
 class QuiToque(AbstractScraper):
@@ -23,7 +28,7 @@ class QuiToque(AbstractScraper):
                 total_time = self._get_text(time).replace(time_name, "")
         return get_minutes(total_time)
 
-    @functools.cached_property
+    @cached_property
     def _nutrients(self):
         return self.soup.find(id="portion")
 

--- a/recipe_scrapers/sunbasket.py
+++ b/recipe_scrapers/sunbasket.py
@@ -1,6 +1,5 @@
-import functools
 from ._abstract import AbstractScraper
-from ._utils import normalize_string
+from ._utils import cached_property, normalize_string
 
 
 class SunBasket(AbstractScraper):
@@ -11,7 +10,7 @@ class SunBasket(AbstractScraper):
     def site_name(self):
         return self.author()
 
-    @functools.cached_property
+    @cached_property
     def _instructions_list(self):
         instructions_container = self.soup.find(
             "div", {"class": "instructions-container"}


### PR DESCRIPTION
## Summary
- add shared `cached_property` alias in `_utils`
- switch scrapers to import the alias instead of `functools`
- document the preferred cached property import style

## Testing
- `pre-commit run --files docs/contributing/code-contribution.md recipe_scrapers/_utils.py recipe_scrapers/americastestkitchen.py recipe_scrapers/bofrost.py recipe_scrapers/farmhousedelivery.py recipe_scrapers/felixkitchen.py recipe_scrapers/goodhousekeeping.py recipe_scrapers/heb.py recipe_scrapers/kitchenaidaustralia.py recipe_scrapers/nhshealthierfamilies.py recipe_scrapers/popsugar.py recipe_scrapers/quitoque.py recipe_scrapers/sunbasket.py` *(failed: CONNECT tunnel failed, response 403)*
- `pytest tests/__init__.py -k 'americastestkitchen or nhs or goodhousekeeping or heb or farmhousedelivery or popsugar or quitoque or sunbasket or kitchenaid or felixkitchen or bofrost'`


------
https://chatgpt.com/codex/tasks/task_e_6896adf234908327a664d55f752988e8