### PR TITLE
Handle unmatched time strings in get_minutes

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -166,7 +166,11 @@ def get_minutes(element):
         except Exception:
             pass
 
-    time_units = TIME_REGEX.search(time_text).groupdict()
+    time_match = TIME_REGEX.search(time_text)
+    if time_match is None:
+        return None
+
+    time_units = time_match.groupdict()
     if not any(time_units.values()):
         return None
 

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -47,6 +47,16 @@ class TestUtils(unittest.TestCase):
             with self.subTest(text=text):
                 self.assertEqual(expected, get_minutes(text))
 
+    def test_unmatched_time_string_returns_none(self):
+        from unittest.mock import patch
+
+        class DummyPattern:
+            def search(self, _):
+                return None
+
+        with patch("recipe_scrapers._utils.TIME_REGEX", new=DummyPattern()):
+            self.assertIsNone(get_minutes("not a time"))
+
     def test_iso8601_fixtures(self):
         # Tests for ISO 8601 formatted outputs formats.
         for text, expected in self.iso8601_fixtures.items():


### PR DESCRIPTION
## Summary
- avoid calling `.groupdict()` when the time regex fails to match
- test unmatched time strings with mocked regex

## Testing
- `pre-commit run --files recipe_scrapers/_utils.py tests/library/test_utils.py` *(fails: unable to access 'https://github.com/pre-commit/pre-commit-hooks/' CONNECT tunnel failed, response 403)*
- `pytest tests/library/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6896adfed528832799f3009d333951b0